### PR TITLE
🐛 Handle missing timestamps in Telegram export converter

### DIFF
--- a/telegram-export-converter.py
+++ b/telegram-export-converter.py
@@ -125,7 +125,10 @@ while cur < len(lines):
             cur += 9
 
         timestamp = re.findall(timestamp_pattern, lines[cur])
-        m.timestamp = timestamp[0]
+        if timestamp:
+            m.timestamp = timestamp[0]
+        else:
+            m.timestamp = None
 
         cur += 4
         m.sender = lines[cur]
@@ -136,7 +139,10 @@ while cur < len(lines):
     else: # Same sender as the message before
         cur += 2
         timestamp = re.findall(timestamp_pattern, lines[cur])
-        m.timestamp = timestamp[0]
+        if timestamp:
+            m.timestamp = timestamp[0]
+        else:
+            m.timestamp = None
 
         m.sender = last_sender
 


### PR DESCRIPTION
Changes to the `toTuple` method to handle cases where the `timestamp` might be missing. Error handling improvements:
* Added a check to set `m.timestamp` to `None` if no timestamp is found in the first occurrence.
* Added a similar check to set `m.timestamp` to `None` if no timestamp is found in the subsequent occurrences.